### PR TITLE
Add missing "Test" scope to testing dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val urlShared = project
   .settings(
     name := s"$projectName-url-shared",
     libraryDependencies ++=
-      Library.scalaTest :: Library.requestScala(scalaVersion.value) :: Nil
+      Library.scalaTest % Test :: Library.requestScala(scalaVersion.value) :: Nil
   )
   .configure(defaultSettings)
   .dependsOn(coreShared)
@@ -94,7 +94,7 @@ lazy val akkaManagement = project
   .in(file("modules/akka/management"))
   .settings(
     name := s"$projectName-akka-management",
-    libraryDependencies += Library.akkaTestKit % Scope.test
+    libraryDependencies += Library.akkaTestKit % Test
   )
   .configure(defaultSettingsWithIt)
   .dependsOn(coreManagement, akkaShared)
@@ -104,7 +104,7 @@ lazy val akkaIO = project
   .in(file("modules/akka/io"))
   .settings(
     name := s"$projectName-akka-io",
-    libraryDependencies += Library.akkaTestKit % Scope.test
+    libraryDependencies += Library.akkaTestKit % Test
   )
   .configure(defaultSettingsWithIt)
   .dependsOn(coreIO, akkaShared)
@@ -117,7 +117,7 @@ lazy val akkaShared = project
   .settings(
     name := s"$projectName-akka-shared",
     libraryDependencies ++=
-      Library.scalaTest :: Library.akkaDep
+      Library.scalaTest % Test :: Library.akkaDep
   )
   .configure(defaultSettings)
   .dependsOn(coreShared)
@@ -145,7 +145,7 @@ lazy val ahcShared = project
   .settings(
     name := s"$projectName-ahc-shared",
     libraryDependencies ++=
-      Library.scalaTest :: Library.asyncDeps
+      Library.scalaTest % Test :: Library.asyncDeps
   )
   .configure(defaultSettings)
   .dependsOn(coreShared)

--- a/project/Library.scala
+++ b/project/Library.scala
@@ -37,7 +37,7 @@ object Library {
     "org.jetbrains"      % "annotations" % "16.0.3",
     "org.testcontainers" % "influxdb"    % "1.12.1" exclude ("org.jetbrains", "annotations") exclude ("org.slf4j", "slf4j-api"),
     "org.slf4j"          % "slf4j-api"   % "1.7.25"
-  )
+  ).map(_ % Scope.test)
 
   // core
   val coreDep: List[ModuleID] = List(
@@ -51,7 +51,7 @@ object Library {
     "com.typesafe.akka" %% "akka-stream" % Versions.Akka.akka exclude ("com.typesafe", "config"),
     "com.typesafe"      %  "config"       % "1.3.4",
     "com.typesafe.akka" %% "akka-http"   % Versions.Akka.akkaHttp,
-    akkaTestKit                                                     % Scope.test
+    akkaTestKit % Scope.test
   )
   // format: on
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4"
+version in ThisBuild := "0.6.5"


### PR DESCRIPTION
Hi there,

We use the following libraries in our project:
```
"com.github.fsanaulla" %% "chronicler-akka-management" % "0.6.4",
"com.github.fsanaulla" %% "chronicler-akka-io" % "0.6.4",
```

Everything was fine until we decide to go for `scalatest 3.2.3` version. Now, I'm no longer able to build my project in JetBrains IDEA: I have a _NoSuchMethodError_ exception:
`java.lang.NoSuchMethodError: 'void org.scalactic.BooleanMacro.<init>(scala.reflect.macros.whitebox.Context)'`

It seems that `scalatest 3.2.3` tries to use some `scalactic 3.0.8` class (_scalatest_ depends on _scalactic_) instead of `scalactic 3.2.3` ? At least, this is what IDEA told me...

Of course, I tried to _exclude_ the _scalatest_ dependency, but it did not work. Maybe `exclude` command has no effect on non transitive "test" scope ? I don't know...

Anyway, using `sbt` in a terminal works fine, and I am able to build the project and produce our final artifact, an RPM package. However, I noticed that `scalatest 3.0.8` and `scalactic 3.0.8` appeared in the libraries inside the RPM. This is not good for us.

So, digging into dependencies tree, I finally figured out that it was `chronicler-akka-shared` who gave us that `scalatest 3.0.8` unwanted dependency.

I made a fork, changed some (very) little things in your sbt build configuration, published locally and gave it a try with our project. 

IT WORKED !!! :+1: 

So we hope this PR will be merged soon and wait for your next release...

Best regards
