### PR TITLE
update jawn ast to 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val coreShared = projectMatrix
     name := s"$projectName-core-shared",
     libraryDependencies ++= List(
       "com.beachape"                                     %% "enumeratum" % "1.6.1",
-      "org.typelevel"                                    %% "jawn-ast" % "0.14.3"
+      "org.typelevel"                                    %% "jawn-ast" % "1.3.0"
     ) ++ (Library.scalaCheck :: Library.scalaTest).map(_ % Test)
   )
   .settings(Settings.propertyTestSettings: _*)


### PR DESCRIPTION
1.3.0 added definition for library scheme and it breaks my build because chronicler depends on too old version